### PR TITLE
Added missing closing html tag.

### DIFF
--- a/cinema.html
+++ b/cinema.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-
+<html lang='en'>
 <!--
 A general Parallel Coordinates-based viewer for Spec-D cinema databases 
 
@@ -46,10 +46,7 @@ OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
 LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
 NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
 EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
 -->
-
-<html lang='en'>
 <head>
 	<title>Cinema:Explorer</title>
 	<meta charset="utf-8">
@@ -116,3 +113,4 @@ EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 	<!--Main Script-->
 	<script src="cinemaapp/js/main.js"></script>
 </body>
+</html>


### PR DESCRIPTION
Fixes it on Firefox 56.0, otherwise shows up as text. (Rather than rendered HTML.)